### PR TITLE
implement useQuery for APIs, and many refactors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,9 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.29.0",
+        "@tanstack/eslint-plugin-query": "^5.12.2",
+        "@tanstack/react-query": "^5.12.2",
+        "@tanstack/react-query-devtools": "^5.13.3",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "@vitejs/plugin-react": "^4.5.2",
@@ -2986,6 +2989,75 @@
         "json5": "^2.2.0",
         "magic-string": "^0.25.0",
         "string.prototype.matchall": "^4.0.6"
+      }
+    },
+    "node_modules/@tanstack/eslint-plugin-query": {
+      "version": "5.81.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/eslint-plugin-query/-/eslint-plugin-query-5.81.2.tgz",
+      "integrity": "sha512-h4k6P6fm5VhKP5NkK+0TTVpGGyKQdx6tk7NYYG7J7PkSu7ClpLgBihw7yzK8N3n5zPaF3IMyErxfoNiXWH/3/A==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/utils": "^8.18.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.82.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.82.0.tgz",
+      "integrity": "sha512-JrjoVuaajBQtnoWSg8iaPHaT4mW73lK2t+exxHNOSMqy0+13eKLqJgTKXKImLejQIfdAHQ6Un0njEhOvUtOd5w==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.81.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.81.2.tgz",
+      "integrity": "sha512-jCeJcDCwKfoyyBXjXe9+Lo8aTkavygHHsUHAlxQKKaDeyT0qyQNLKl7+UyqYH2dDF6UN/14873IPBHchcsU+Zg==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.82.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.82.0.tgz",
+      "integrity": "sha512-mnk8/ofKEthFeMdhV1dV8YXRf+9HqvXAcciXkoo755d/ocfWq7N/Y9jGOzS3h7ZW9dDGwSIhs3/HANWUBsyqYg==",
+      "dev": true,
+      "dependencies": {
+        "@tanstack/query-core": "5.82.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.82.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.82.0.tgz",
+      "integrity": "sha512-MC05Zq3zr/59jhgF7dL6JSGPg1krbasDSizmRxjNcvxgh/sUTwRFD9CGN10YYX7LB6jq0ZpFtCjSVGdLiFrKAA==",
+      "dev": true,
+      "dependencies": {
+        "@tanstack/query-devtools": "5.81.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.82.0",
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@types/babel__core": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",
+    "@tanstack/eslint-plugin-query": "^5.12.2",
+    "@tanstack/react-query": "^5.12.2",
+    "@tanstack/react-query-devtools": "^5.13.3",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.5.2",

--- a/src/apis/categories.ts
+++ b/src/apis/categories.ts
@@ -1,0 +1,22 @@
+import type { ICategory } from "../models";
+
+export function getCategories(): ICategory[] {
+  //TODO: GET from db
+  return [
+    {
+      _id: "1",
+      title: "ACC",
+      color: "blue",
+    },
+    {
+      _id: "2",
+      title: "Private",
+      color: "green",
+    },
+  ];
+}
+
+export function addCategory(category: ICategory) {
+  // TODO: POST to db
+  console.log(category); 
+}

--- a/src/apis/clients.ts
+++ b/src/apis/clients.ts
@@ -1,0 +1,30 @@
+export function getAllClientNames() {
+  // TODO: GET from db
+  return [
+    {
+      id: 1,
+      label: "Jared Pinfold",
+    },
+    { id: 2, label: "Daph Simons" },
+    { id: 3, label: "Destroy Orbison" },
+  ];
+}
+export function getClientById(id: number) {
+  // TODO: GET from db
+  console.log(id);
+}
+
+export function addClient(client: unknown) {
+  // TODO: POST to db
+  console.log(client);
+}
+
+export function updateClient(client: unknown) {
+  // TODO: PUT to db
+  console.log(client);
+}
+
+export function deleteClient(client) {
+  // TODO: DELETE to db
+  console.log(client);
+}

--- a/src/components/AddCategoryModal.tsx
+++ b/src/components/AddCategoryModal.tsx
@@ -1,5 +1,5 @@
-import { useState, } from "react"
-import type { Dispatch, SetStateAction } from "react"
+import { useState } from "react";
+import type { Dispatch, SetStateAction } from "react";
 import {
   Dialog,
   DialogActions,
@@ -14,26 +14,31 @@ import {
   ListItem,
   ListItemText,
   TextField,
-} from "@mui/material"
-import DeleteIcon from "@mui/icons-material/Delete"
+} from "@mui/material";
+import DeleteIcon from "@mui/icons-material/Delete";
 
-import { HexColorPicker } from "react-colorful"
-import { type ICategory } from "./AppointmentCalendar"
-import { generateId } from "../utils"
+import { HexColorPicker } from "react-colorful";
+import { type ICategory } from "../models";
+import { generateId } from "../utils";
 
 interface IProps {
-  open: boolean
-  handleClose: Dispatch<SetStateAction<void>>
-  categories: ICategory[]
-  setCategories: Dispatch<SetStateAction<ICategory[]>>
+  open: boolean;
+  handleClose: Dispatch<SetStateAction<void>>;
+  categories: ICategory[];
+  setCategories: Dispatch<SetStateAction<ICategory[]>>;
 }
 
-export const AddCategoryModal = ({ open, handleClose, categories, setCategories }: IProps) => {
-  const [color, setColor] = useState("#b32aa9")
-  const [title, setTitle] = useState("")
+export function AddCategoryModal({
+  open,
+  handleClose,
+  categories,
+  setCategories,
+}: IProps) {
+  const [color, setColor] = useState("#b32aa9");
+  const [title, setTitle] = useState("");
 
-  const onAddCategory = () => {
-    setTitle("")
+  function onAddCategory() {
+    setTitle("");
     setCategories([
       ...categories,
       {
@@ -41,18 +46,24 @@ export const AddCategoryModal = ({ open, handleClose, categories, setCategories 
         color,
         title,
       },
-    ])
+    ]);
   }
 
-  const onDeleteCategory = (_id: string) => setCategories(categories.filter((category) => category._id !== _id))
+  function onDeleteCategory(_id: string) {
+    setCategories(categories.filter((category) => category._id !== _id));
+  }
 
-  const onClose = () => handleClose()
+  function onClose() {
+    handleClose();
+  }
 
   return (
     <Dialog open={open} onClose={onClose}>
       <DialogTitle>Add category</DialogTitle>
       <DialogContent>
-        <DialogContentText>Create categories for your appointments.</DialogContentText>
+        <DialogContentText>
+          Create categories for your appointments.
+        </DialogContentText>
         <Box>
           <TextField
             name="title"
@@ -66,13 +77,17 @@ export const AddCategoryModal = ({ open, handleClose, categories, setCategories 
             required
             variant="outlined"
             onChange={(e) => {
-              setTitle(e.target.value)
+              setTitle(e.target.value);
             }}
             value={title}
           />
           <Box sx={{ display: "flex", justifyContent: "space-around" }}>
             <HexColorPicker color={color} onChange={setColor} />
-            <Box sx={{ height: 80, width: 80, borderRadius: 1 }} className="value" style={{ backgroundColor: color }}></Box>
+            <Box
+              sx={{ height: 80, width: 80, borderRadius: 1 }}
+              className="value"
+              style={{ backgroundColor: color }}
+            ></Box>
           </Box>
           <Box>
             <List sx={{ marginTop: 3 }}>
@@ -80,13 +95,22 @@ export const AddCategoryModal = ({ open, handleClose, categories, setCategories 
                 <ListItem
                   key={category.title}
                   secondaryAction={
-                    <IconButton onClick={() => onDeleteCategory(category._id)} color="error" edge="end">
+                    <IconButton
+                      onClick={() => onDeleteCategory(category._id)}
+                      color="error"
+                      edge="end"
+                    >
                       <DeleteIcon />
                     </IconButton>
                   }
                 >
                   <Box
-                    sx={{ height: 40, width: 40, borderRadius: 1, marginRight: 1 }}
+                    sx={{
+                      height: 40,
+                      width: 40,
+                      borderRadius: 1,
+                      marginRight: 1,
+                    }}
                     className="value"
                     style={{ backgroundColor: category.color }}
                   ></Box>
@@ -99,7 +123,12 @@ export const AddCategoryModal = ({ open, handleClose, categories, setCategories 
       </DialogContent>
       <Divider />
       <DialogActions sx={{ marginTop: 2 }}>
-        <Button sx={{ marginRight: 2 }} variant="contained" color="error" onClick={onClose}>
+        <Button
+          sx={{ marginRight: 2 }}
+          variant="contained"
+          color="error"
+          onClick={onClose}
+        >
           Cancel
         </Button>
         <Button
@@ -113,5 +142,5 @@ export const AddCategoryModal = ({ open, handleClose, categories, setCategories 
         </Button>
       </DialogActions>
     </Dialog>
-  )
+  );
 }

--- a/src/components/AddDatePickerAppointmentModal.tsx
+++ b/src/components/AddDatePickerAppointmentModal.tsx
@@ -1,4 +1,4 @@
-import type { Dispatch, MouseEvent, SetStateAction, ChangeEvent } from "react"
+import type { Dispatch, MouseEvent, SetStateAction, ChangeEvent } from "react";
 import {
   TextField,
   Dialog,
@@ -10,28 +10,31 @@ import {
   Autocomplete,
   Box,
   Typography,
-} from "@mui/material"
+} from "@mui/material";
 // import { LocalizationProvider, DateTimePicker } from "@mui/x-date-pickers"
-import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFns"
+import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFns";
 import {
   LocalizationProvider,
   DatePicker,
   MultiSectionDigitalClock,
-} from "@mui/x-date-pickers"
-import dayjs from 'dayjs'
-import type { DatePickerAppointmentFormData, ICategory } from "./AppointmentCalendar"
-import { getAllClientNames } from "../apis/clients"
-import { useQuery } from "@tanstack/react-query"
+} from "@mui/x-date-pickers";
+import dayjs from "dayjs";
+import type { DatePickerAppointmentFormData, ICategory } from "../models";
+import { getAllClientNames } from "../apis/clients";
+import { useQuery } from "@tanstack/react-query";
 
 interface IProps {
-  open: boolean
-  handleClose: Dispatch<SetStateAction<void>>
-  datePickerAppointmentFormData: DatePickerAppointmentFormData
-  setDatePickerAppointmentFormData: Dispatch<SetStateAction<DatePickerAppointmentFormData>>
-  onAddAppointment: (e: MouseEvent<HTMLButtonElement>) => void
-  categories: ICategory[]
+  open: boolean;
+  handleClose: Dispatch<SetStateAction<void>>;
+  datePickerAppointmentFormData: DatePickerAppointmentFormData;
+  setDatePickerAppointmentFormData: Dispatch<
+    SetStateAction<DatePickerAppointmentFormData>
+  >;
+  onAddAppointment: (e: MouseEvent<HTMLButtonElement>) => void;
+  categories: ICategory[];
 }
 
+/////////////////////////////////////////////////////////////////////////////
 export default function AddDatePickerAppointmentModal({
   open,
   handleClose,
@@ -40,70 +43,78 @@ export default function AddDatePickerAppointmentModal({
   onAddAppointment,
   categories,
 }: IProps) {
-  const { client, start, end, allDay, notes } = datePickerAppointmentFormData
+  const { client, start, end, allDay, notes } = datePickerAppointmentFormData;
 
-  const {data: clients, loading, error} = useQuery({
-    queryKey: ['clientNamesForDropdown'],
-    queryFn: () => getAllClientNames()
-  })
-  const onClose = () => {
-    handleClose()
+  const { data: clients } = useQuery({
+    queryKey: ["clientNamesForDropdown"],
+    queryFn: () => getAllClientNames(),
+  });
+  function onClose() {
+    handleClose();
   }
 
-  const onChange = (e: ChangeEvent<HTMLInputElement>) => {
+  function onChange(e: ChangeEvent<HTMLInputElement>) {
     setDatePickerAppointmentFormData((prevState) => ({
       ...prevState,
       [e.target.name]: e.target.value,
-    }))
+    }));
   }
 
-
-  const handleCategoryChange = (e: React.SyntheticEvent, value: ICategory | null) => {
+  function handleCategoryChange(
+    _e: React.SyntheticEvent,
+    value: ICategory | null
+  ) {
     setDatePickerAppointmentFormData((prevState) => ({
       ...prevState,
       categoryId: value?._id,
-    }))
+    }));
   }
 
   // Handle Date change
-  const handleDateChange = (newValue: Date | null) => {
+  function handleDateChange(newValue: Date | null) {
     setDatePickerAppointmentFormData((prevState) => ({
       ...prevState,
       // Update both start and end dates to maintain the same date
       start: newValue ? new Date(newValue) : undefined,
-      end: newValue && prevState.end ?
-        new Date(newValue.getFullYear(), newValue.getMonth(), newValue.getDate(),
-          prevState.end.getHours(), prevState.end.getMinutes()) :
-        undefined,
-    }))
+      end:
+        newValue && prevState.end
+          ? new Date(
+              newValue.getFullYear(),
+              newValue.getMonth(),
+              newValue.getDate(),
+              prevState.end.getHours(),
+              prevState.end.getMinutes()
+            )
+          : undefined,
+    }));
   }
   // Handle start time change
-  const handleStartTimeChange = (newValue: Date | null) => {
+  function handleStartTimeChange(newValue: Date | null) {
     if (newValue && start) {
       // Combine the existing date with the new time
-      const updatedStart = new Date(start)
-      updatedStart.setHours(newValue.getHours())
-      updatedStart.setMinutes(newValue.getMinutes())
+      const updatedStart = new Date(start);
+      updatedStart.setHours(newValue.getHours());
+      updatedStart.setMinutes(newValue.getMinutes());
 
       setDatePickerAppointmentFormData((prevState) => ({
         ...prevState,
         start: updatedStart,
-      }))
+      }));
     }
   }
 
   // Handle end time change
-  const handleEndTimeChange = (newValue: Date | null) => {
+  function handleEndTimeChange(newValue: Date | null) {
     if (newValue && start) {
       // Combine the existing date with the new time
-      const updatedEnd = new Date(start) // Use start date as base
-      updatedEnd.setHours(newValue.getHours())
-      updatedEnd.setMinutes(newValue.getMinutes())
+      const updatedEnd = new Date(start); // Use start date as base
+      updatedEnd.setHours(newValue.getHours());
+      updatedEnd.setMinutes(newValue.getMinutes());
 
       setDatePickerAppointmentFormData((prevState) => ({
         ...prevState,
         end: updatedEnd,
-      }))
+      }));
     }
   }
 
@@ -117,41 +128,43 @@ export default function AddDatePickerAppointmentModal({
   //     }))
   //   }
   // }
-  const isDisabled = () => {
+  function isDisabled() {
     const checkend = () => {
       if (!allDay && end === null) {
-        return true
+        return true;
       }
-    }
+    };
     if (client === "" || start === null || checkend()) {
-      return true
+      return true;
     }
-    return false
+    return false;
   }
 
   return (
     <Dialog open={open} onClose={onClose}>
       <DialogTitle variant="h5">Add appointment</DialogTitle>
       <DialogContent>
-        <DialogContentText>To add a appointment, please fill in the information below.</DialogContentText>
+        <DialogContentText>
+          To add a appointment, please fill in the information below.
+        </DialogContentText>
         <Box component="form">
-
           {/* Client Name: */}
           <Typography variant="h6" color="primary" sx={{ mt: 2 }}>
             Client
           </Typography>
           <Autocomplete
             disablePortal
-            options={clients}
+            options={clients || []}
             sx={{ width: 300, mb: 2, mt: 1 }}
             onChange={(_, newValue) =>
               setDatePickerAppointmentFormData((prevState) => ({
                 ...prevState,
-                client: newValue?.label ?? '', // Default value if newValue is null              
+                client: newValue?.label ?? "", // Default value if newValue is null
               }))
             }
-            renderInput={(params) => <TextField {...params} label="Enter client name" />}
-
+            renderInput={(params) => (
+              <TextField {...params} label="Enter client name" />
+            )}
           />
 
           {/* Date: */}
@@ -164,7 +177,10 @@ export default function AddDatePickerAppointmentModal({
                 label="Select date"
                 value={start}
                 onChange={handleDateChange}
-                renderInput={(params) => <TextField {...params} halfWidth />}
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                renderInput={(params: any) => (
+                  <TextField {...params} halfWidth />
+                )}
               />
             </Box>
 
@@ -174,8 +190,14 @@ export default function AddDatePickerAppointmentModal({
               </Typography>
             </Box>
 
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, flexWrap: 'wrap' }}>
-
+            <Box
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                gap: 2,
+                flexWrap: "wrap",
+              }}
+            >
               {/* // STRETCH: handle both start and end time in a single input and handler function */}
               {/* <TimeRangePicker
                 value={value}
@@ -183,37 +205,40 @@ export default function AddDatePickerAppointmentModal({
               /> */}
               {/* Start Time */}
               <Box>
-                <Typography variant="body1" sx={{ mb: 1 }}>Start Time</Typography>
+                <Typography variant="body1" sx={{ mb: 1 }}>
+                  Start Time
+                </Typography>
                 <MultiSectionDigitalClock
                   value={start}
                   onChange={handleStartTimeChange}
                   sx={{
-                    border: '1px solid #e0e0e0',
+                    border: "1px solid #e0e0e0",
                     borderRadius: 1,
                     maxHeight: 50,
-                    overflow: 'auto'
+                    overflow: "auto",
                   }}
                 />
-
               </Box>
 
               {/* "to" separator */}
-              <Typography variant="h6" sx={{ mt: 3 }} >
+              <Typography variant="h6" sx={{ mt: 3 }}>
                 to
               </Typography>
 
               {/* End Time */}
               <Box>
-                <Typography variant="body1" sx={{ mb: 1 }}>End Time</Typography>
+                <Typography variant="body1" sx={{ mb: 1 }}>
+                  End Time
+                </Typography>
                 <MultiSectionDigitalClock
                   value={end}
                   onChange={handleEndTimeChange}
                   minTime={start ? dayjs(start).toDate() : undefined}
                   sx={{
-                    border: '1px solid #e0e0e0',
+                    border: "1px solid #e0e0e0",
                     borderRadius: 1,
                     maxHeight: 50,
-                    overflow: 'auto'
+                    overflow: "auto",
                   }}
                 />
               </Box>
@@ -232,7 +257,9 @@ export default function AddDatePickerAppointmentModal({
               options={categories}
               sx={{ mt: 1 }}
               getOptionLabel={(option) => option.title}
-              renderInput={(params) => <TextField {...params} label="Select a category" />}
+              renderInput={(params) => (
+                <TextField {...params} label="Select a category" />
+              )}
             />
           </Box>
           {/* Notes:  */}
@@ -253,16 +280,19 @@ export default function AddDatePickerAppointmentModal({
             />
           </Box>
         </Box>
-      </DialogContent >
+      </DialogContent>
       <DialogActions>
         <Button color="error" onClick={onClose}>
           Cancel
         </Button>
-        <Button disabled={isDisabled()} color="success" onClick={onAddAppointment}>
+        <Button
+          disabled={isDisabled()}
+          color="success"
+          onClick={onAddAppointment}
+        >
           Add
         </Button>
       </DialogActions>
-    </Dialog >
-  )
+    </Dialog>
+  );
 }
-

--- a/src/components/AddDatePickerAppointmentModal.tsx
+++ b/src/components/AddDatePickerAppointmentModal.tsx
@@ -20,6 +20,8 @@ import {
 } from "@mui/x-date-pickers"
 import dayjs from 'dayjs'
 import type { DatePickerAppointmentFormData, ICategory } from "./AppointmentCalendar"
+import { getAllClientNames } from "../apis/clients"
+import { useQuery } from "@tanstack/react-query"
 
 interface IProps {
   open: boolean
@@ -40,13 +42,10 @@ export default function AddDatePickerAppointmentModal({
 }: IProps) {
   const { client, start, end, allDay, notes } = datePickerAppointmentFormData
 
-  const clients = [ // TODO API
-    {
-      id: 1,
-      label: "Jared Pinfold",
-    },
-    { id: 2, label: "Daph Simons" },
-  ];
+  const {data: clients, loading, error} = useQuery({
+    queryKey: ['clientNamesForDropdown'],
+    queryFn: () => getAllClientNames()
+  })
   const onClose = () => {
     handleClose()
   }

--- a/src/components/AppointmentCalendar.tsx
+++ b/src/components/AppointmentCalendar.tsx
@@ -28,7 +28,7 @@ import { AddCategoryModal } from "./AddCategoryModal";
 import AddDatePickerAppointmentModal from "./AddDatePickerAppointmentModal";
 import { generateId } from "../utils";
 import { localizer } from "../localizer";
-console.log(localizer);
+
 export function AppointmentCalendar() {
   const [date, setDate] = useState(new Date());
   const initialDatePickerAppointmentFormData: DatePickerAppointmentFormData = {

--- a/src/components/AppointmentCalendar.tsx
+++ b/src/components/AppointmentCalendar.tsx
@@ -11,15 +11,14 @@ import {
   Divider,
 } from "@mui/material";
 
-import { Calendar, dateFnsLocalizer } from "react-big-calendar";
+import { Calendar } from "react-big-calendar";
 
 import type { Event } from "react-big-calendar";
-
-import { format } from "date-fns/format";
-import { parse } from "date-fns/parse";
-import { startOfWeek } from "date-fns/startOfWeek";
-import { getDay } from "date-fns/getDay";
-import { enNZ } from "date-fns/locale/en-NZ";
+import type {
+  ICategory,
+  IAppointmentInfo,
+  DatePickerAppointmentFormData,
+} from "../models";
 
 import "react-big-calendar/lib/css/react-big-calendar.css";
 
@@ -28,45 +27,7 @@ import AppointmentInfoModal from "./AppointmentInfoModal";
 import { AddCategoryModal } from "./AddCategoryModal";
 import AddDatePickerAppointmentModal from "./AddDatePickerAppointmentModal";
 import { generateId } from "../utils";
-
-const locales = {
-  "en-NZ": enNZ,
-};
-
-const localizer = dateFnsLocalizer({
-  format,
-  parse,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  startOfWeek: (date: any) => startOfWeek(date, { weekStartsOn: 1 }),
-  getDay,
-  locales,
-});
-
-export interface ICategory {
-  _id: string;
-  title: string;
-  color?: string;
-}
-
-export interface IAppointmentInfo extends Event {
-  _id: string;
-  notes?: string;
-  categoryId?: string;
-}
-
-export interface AppointmentFormData {
-  notes?: string;
-  categoryId?: string;
-}
-
-export interface DatePickerAppointmentFormData {
-  client: string;
-  categoryId?: string;
-  allDay: boolean;
-  start?: Date;
-  end?: Date;
-  notes?: string;
-}
+import { localizer } from "../localizer";
 
 export function AppointmentCalendar() {
   const [date, setDate] = useState(new Date());
@@ -79,18 +40,19 @@ export function AppointmentCalendar() {
     notes: "",
   };
 
-  const categoriesTemp = [ //TODO API
+  const categoriesTemp = [
+    //TODO API
     {
       _id: "1",
       title: "ACC",
-      color: "blue"
+      color: "blue",
     },
     {
       _id: "2",
       title: "Private",
-      color: "green"
-    }
-  ]
+      color: "green",
+    },
+  ];
   // States
   const [openDatepickerModal, setOpenDatepickerModal] = useState(false);
   const [openCategoryModal, setOpenCategoryModal] = useState(false);
@@ -108,22 +70,22 @@ export function AppointmentCalendar() {
 
   // Form Data
 
-  const handleSelectSlot = (appointment: Event) => {
+  function handleSelectSlot(appointment: Event) {
     setOpenDatepickerModal(true);
     setCurrentAppointment(appointment);
-  };
+  }
 
-  const handleSelectAppointment = (appointment: IAppointmentInfo) => {
+  function handleSelectAppointment(appointment: IAppointmentInfo) {
     setCurrentAppointment(appointment);
     setAppointmentInfoModal(true);
-  };
+  }
 
-  const handleDatePickerClose = () => {
+  function handleDatePickerClose() {
     setDatePickerAppointmentFormData(initialDatePickerAppointmentFormData);
     setOpenDatepickerModal(false);
-  };
+  }
 
-  const onAddAppointmentFromDatePicker = (e: MouseEvent<HTMLButtonElement>) => {
+  function onAddAppointmentFromDatePicker(e: MouseEvent<HTMLButtonElement>) {
     e.preventDefault();
 
     const addHours = (date: Date | undefined, hours: number) => {
@@ -153,7 +115,7 @@ export function AppointmentCalendar() {
     setDatePickerAppointmentFormData(initialDatePickerAppointmentFormData);
   };
 
-  const onDeleteAppointment = () => {
+  function onDeleteAppointment() {
     setAppointments(() =>
       [...appointments].filter(
         (e) => e._id !== (currentAppointment as IAppointmentInfo)._id!

--- a/src/components/AppointmentCalendar.tsx
+++ b/src/components/AppointmentCalendar.tsx
@@ -28,7 +28,7 @@ import { AddCategoryModal } from "./AddCategoryModal";
 import AddDatePickerAppointmentModal from "./AddDatePickerAppointmentModal";
 import { generateId } from "../utils";
 import { localizer } from "../localizer";
-
+console.log(localizer);
 export function AppointmentCalendar() {
   const [date, setDate] = useState(new Date());
   const initialDatePickerAppointmentFormData: DatePickerAppointmentFormData = {
@@ -113,7 +113,7 @@ export function AppointmentCalendar() {
 
     setAppointments(newAppointments);
     setDatePickerAppointmentFormData(initialDatePickerAppointmentFormData);
-  };
+  }
 
   function onDeleteAppointment() {
     setAppointments(() =>
@@ -122,7 +122,7 @@ export function AppointmentCalendar() {
       )
     );
     setAppointmentInfoModal(false);
-  };
+  }
 
   const onNavigate = useCallback((newDate: Date) => {
     setDate(newDate);

--- a/src/components/AppointmentInfo.tsx
+++ b/src/components/AppointmentInfo.tsx
@@ -1,6 +1,6 @@
-import { Typography } from "@mui/material"
-import type { IAppointmentInfo } from "./AppointmentCalendar"
-import type { EventProps } from 'react-big-calendar';
+import { Typography } from "@mui/material";
+import type { IAppointmentInfo } from "../models";
+import type { EventProps } from "react-big-calendar";
 
 // interface IProps extends EventProps<IAppointmentInfo> {
 //   appointment: IAppointmentInfo
@@ -13,7 +13,7 @@ const AppointmentInfo = ({ event }: EventProps<IAppointmentInfo>) => {
     <>
       <Typography>{event.description}</Typography>
     </>
-  )
-}
+  );
+};
 
-export default AppointmentInfo
+export default AppointmentInfo;

--- a/src/components/AppointmentInfoModal.tsx
+++ b/src/components/AppointmentInfoModal.tsx
@@ -1,19 +1,32 @@
-import type { SetStateAction, MouseEvent, Dispatch } from "react"
-import { Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, Button, Box, Typography } from "@mui/material"
-import type { IAppointmentInfo } from "./AppointmentCalendar"
+import type { SetStateAction, MouseEvent, Dispatch } from "react";
+import {
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  Button,
+  Box,
+  Typography,
+} from "@mui/material";
+import type { IAppointmentInfo } from "../models";
 
 interface IProps {
-  open: boolean
-  handleClose: Dispatch<SetStateAction<void>>
-  onDeleteAppointment: (e: MouseEvent<HTMLButtonElement>) => void
-  currentAppointment: IAppointmentInfo | null
+  open: boolean;
+  handleClose: Dispatch<SetStateAction<void>>;
+  onDeleteAppointment: (e: MouseEvent<HTMLButtonElement>) => void;
+  currentAppointment: IAppointmentInfo | null;
 }
 
-const AppointmentInfoModal = ({ open, handleClose, onDeleteAppointment, currentAppointment }: IProps) => {
-
-  // TODO: Add an update functionality in this 
-  const onClose = () => {
-    handleClose()
+function AppointmentInfoModal({
+  open,
+  handleClose,
+  onDeleteAppointment,
+  currentAppointment,
+}: IProps) {
+  // TODO: Add an update functionality in this
+  function onClose() {
+    handleClose();
   }
 
   return (
@@ -21,7 +34,11 @@ const AppointmentInfoModal = ({ open, handleClose, onDeleteAppointment, currentA
       <DialogTitle>Appointment Info</DialogTitle>
       <DialogContent>
         <DialogContentText>
-          <Typography sx={{ fontSize: 14, marginTop: 3 }} color="text.secondary" gutterBottom>
+          <Typography
+            sx={{ fontSize: 14, marginTop: 3 }}
+            color="text.secondary"
+            gutterBottom
+          >
             {currentAppointment?.description}
           </Typography>
         </DialogContentText>
@@ -36,7 +53,7 @@ const AppointmentInfoModal = ({ open, handleClose, onDeleteAppointment, currentA
         </Button>
       </DialogActions>
     </Dialog>
-  )
+  );
 }
 
-export default AppointmentInfoModal
+export default AppointmentInfoModal;

--- a/src/localizer.ts
+++ b/src/localizer.ts
@@ -1,0 +1,19 @@
+import { format } from "date-fns/format";
+import { parse } from "date-fns/parse";
+import { startOfWeek } from "date-fns/startOfWeek";
+import { getDay } from "date-fns/getDay";
+import { enNZ } from "date-fns/locale/en-NZ";
+import { dateFnsLocalizer } from "react-big-calendar";
+
+const locales = {
+  "en-NZ": enNZ,
+};
+
+export const localizer = dateFnsLocalizer({
+  format,
+  parse,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  startOfWeek: (date: any) => startOfWeek(date, { weekStartsOn: 1 }),
+  getDay,
+  locales,
+});

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,17 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App.tsx'
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+// import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import "./index.css";
+import App from "./App.tsx";
 
-createRoot(document.getElementById('root')!).render(
+const queryClient = new QueryClient();
+
+createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <App />
-  </StrictMode>,
-)
+    <QueryClientProvider client={queryClient}>
+      {/* <ReactQueryDevtools /> */}
+      <App />
+    </QueryClientProvider>
+  </StrictMode>
+);

--- a/src/models.ts
+++ b/src/models.ts
@@ -1,0 +1,27 @@
+import type { Event } from "react-big-calendar";
+
+export interface ICategory {
+  _id: string;
+  title: string;
+  color?: string;
+}
+
+export interface IAppointmentInfo extends Event {
+  _id: string;
+  notes?: string;
+  categoryId?: string;
+}
+
+// export interface AppointmentFormData {
+//   notes?: string;
+//   categoryId?: string;
+// }
+
+export interface DatePickerAppointmentFormData {
+  client: string;
+  categoryId?: string;
+  allDay: boolean;
+  start?: Date;
+  end?: Date;
+  notes?: string;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,1 +1,3 @@
-export const generateId = () => (Math.floor(Math.random() * 10000) + 1).toString()
+export function generateId() {
+  return (Math.floor(Math.random() * 10000) + 1).toString();
+}


### PR DESCRIPTION
This is a ridiculous PR:

Implemented useQuery
Created a bunch of empty CRUD functions for client and category operations

Refactors:
- all of the localizer stuff out opf the calendar component into its own file
- models into their own file
- consts with fat arrows into proper functions
